### PR TITLE
Rename RedisCache.redis_url to url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ description = ""
 name = "ab-cache"
 readme = "README.md"
 requires-python = ">=3.12, <4"
-version = "0.1.10"
+version = "0.1.11"
 
 [project.optional-dependencies]
 all = ["redis>=6.4.0,<7", "diskcache>=5.6.3,<6"]

--- a/src/ab_core/cache/caches/redis.py
+++ b/src/ab_core/cache/caches/redis.py
@@ -309,7 +309,7 @@ class RedisCacheAsyncSession(CacheAsyncSession):
 class RedisCache(CacheBase[RedisCacheSession, RedisCacheAsyncSession]):
     type: Literal[CacheType.REDIS] = CacheType.REDIS
 
-    redis_url: str
+    url: str
     username: str | None = None
     password: str | None = None
     cluster: bool = Field(False, description="Use Redis Cluster")
@@ -340,12 +340,12 @@ class RedisCache(CacheBase[RedisCacheSession, RedisCacheAsyncSession]):
         """Synchronous client (standalone or cluster)."""
         if self.cluster:
             return SyncRedisClusterClient.from_url(
-                self.redis_url,
+                self.url,
                 username=self.username,
                 password=self.password,
             )
         return SyncRedisClient.from_url(
-            self.redis_url,
+            self.url,
             username=self.username,
             password=self.password,
         )
@@ -354,12 +354,12 @@ class RedisCache(CacheBase[RedisCacheSession, RedisCacheAsyncSession]):
         """Async client (standalone or cluster)."""
         if self.cluster:
             return AsyncRedisClusterClient.from_url(
-                self.redis_url,
+                self.url,
                 username=self.username,
                 password=self.password,
             )
         return AsyncRedisClient.from_url(
-            self.redis_url,
+            self.url,
             username=self.username,
             password=self.password,
         )


### PR DESCRIPTION
Rename the RedisCache configuration field from `redis_url` to `url` and update all usages when constructing sync/async, standalone and cluster Redis clients. Keeps username/password and cluster behavior unchanged; updates calls to from_url to use the new attribute name.